### PR TITLE
feat(dto): introduce LessonResponse DTO and request/response layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>2.7.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>2.7.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/mentorguild/dto/LessonRequest.java
+++ b/src/main/java/com/mentorguild/dto/LessonRequest.java
@@ -1,0 +1,53 @@
+package com.mentorguild.dto;
+
+import java.util.UUID;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public class LessonRequest {
+    @NotNull
+    private UUID mentorId;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String topic;
+
+    @NotBlank
+    private String content;
+
+    private String[] tags;
+
+    public LessonRequest() {
+    }
+
+    public LessonRequest(UUID mentorId, String title, String topic, String content, String[] tags) {
+        this.mentorId = mentorId;
+        this.title = title;
+        this.topic = topic;
+        this.content = content;
+        this.tags = tags;
+    }
+
+    public UUID getMentorId() {
+        return mentorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String[] getTags() {
+        return tags;
+    }
+}

--- a/src/main/java/com/mentorguild/dto/LessonResponse.java
+++ b/src/main/java/com/mentorguild/dto/LessonResponse.java
@@ -1,0 +1,46 @@
+package com.mentorguild.dto;
+
+import java.util.UUID;
+
+public class LessonResponse {
+    private final UUID lessonId;
+    private final MentorResponse mentor;
+    private final String title;
+    private final String topic;
+    private final String content;
+    private final String[] tags;
+
+    public LessonResponse(UUID lessonId, MentorResponse mentor, String title,
+                          String topic, String content, String[] tags) {
+        this.lessonId = lessonId;
+        this.mentor = mentor;
+        this.title = title;
+        this.topic = topic;
+        this.content = content;
+        this.tags = tags != null ? tags.clone() : null;
+    }
+
+    public UUID getLessonId() {
+        return lessonId;
+    }
+
+    public MentorResponse getMentor() {
+        return mentor;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String[] getTags() {
+        return tags != null ? tags.clone() : null;
+    }
+}

--- a/src/main/java/com/mentorguild/dto/MentorResponse.java
+++ b/src/main/java/com/mentorguild/dto/MentorResponse.java
@@ -1,0 +1,27 @@
+package com.mentorguild.dto;
+
+import java.util.UUID;
+
+public class MentorResponse {
+    private final UUID id;
+    private final String name;
+    private final String catchphrase;
+
+    public MentorResponse(UUID id, String name, String catchphrase) {
+        this.id = id;
+        this.name = name;
+        this.catchphrase = catchphrase;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCatchphrase() {
+        return catchphrase;
+    }
+}

--- a/src/main/java/com/mentorguild/mapper/LessonMapper.java
+++ b/src/main/java/com/mentorguild/mapper/LessonMapper.java
@@ -1,0 +1,51 @@
+package com.mentorguild.mapper;
+
+import java.util.Objects;
+
+import com.mentorguild.dto.LessonRequest;
+import com.mentorguild.dto.LessonResponse;
+import com.mentorguild.dto.MentorResponse;
+import com.mentorguild.model.Lesson;
+import com.mentorguild.model.Mentor;
+
+public class LessonMapper {
+
+    public static MentorResponse toMentorResponse(Mentor mentor) {
+        if (mentor == null) {
+            return null;
+        }
+        return new MentorResponse(
+                mentor.getIdNumber(),
+                mentor.getName(),
+                mentor.getCatchphrase()
+        );
+    }
+
+    public static LessonResponse toLessonResponse(Lesson lesson) {
+        if (lesson == null) {
+            return null;
+        }
+        return new LessonResponse(
+                lesson.getLessonId(),
+                toMentorResponse(lesson.getMentor()),
+                lesson.getTitle(),
+                lesson.getTopic(),
+                lesson.getContent(),
+                lesson.getTags()
+        );
+    }
+
+    public static Lesson toLesson(LessonRequest request, Mentor mentor) {
+        if (request == null) {
+            return null;
+        }
+        Objects.requireNonNull(mentor, "Mentor must not be null when creating a Lesson");
+        return new Lesson(
+                mentor,
+                request.getTitle(),
+                request.getTopic(),
+                request.getContent(),
+                request.getTags()
+        );
+    }
+}


### PR DESCRIPTION
- Add LessonResponse, MentorResponse DTOs for API responses
- Add LessonRequest DTO with validation (@NotNull, @NotBlank)
- Add LessonMapper utility for entity-DTO conversions
- Add spring-boot-starter-validation dependency
- Use defensive copies for tags array to ensure immutability

Closes #12

